### PR TITLE
Handle `use` keywords with leading backslashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ use AnotherDummy\{
 use Dummy\SubOtherDummy;
 use OtherDummy\SubOtherDummy;
 use RuntimeException;
+use \UnexpectedValueException;
 
 class DummyClass
 {
@@ -151,6 +152,7 @@ use My\App\Vendor\AnotherDummy\{
 use My\App\Vendor\Dummy\SubOtherDummy;
 use My\App\Vendor\OtherDummy\SubOtherDummy;
 use RuntimeException;
+use \UnexpectedValueException;
 
 class DummyClass
 {

--- a/src/Transformer.php
+++ b/src/Transformer.php
@@ -127,7 +127,7 @@ final class Transformer implements TransformerInterface
     private function prefixUse(string $targetFile)
     {
         $pattern     = sprintf(
-            '/%1$s\\s+(?!(%2$s)|(Composer(\\\\|;)|(?!.*\\\\.*)))/',
+            '/%1$s\\s+(?!(%2$s)|(\\\\(?!.*\\\\.*))|(Composer(\\\\|;)|(?!.*\\\\.*)))/',
             'use',
             $this->namespacePrefix
         );

--- a/tests/_data/fake-vendor/dummy/dummy/DummyClass.php
+++ b/tests/_data/fake-vendor/dummy/dummy/DummyClass.php
@@ -11,6 +11,7 @@ use Dummy\SubOtherDummy;
 use OtherDummy\SubOtherDummy;
 use TypistTech\Imposter\Plugin;
 use RuntimeException;
+use \UnexpectedValueException;
 
 class DummyClass
 {

--- a/tests/unit/TransformerTest.php
+++ b/tests/unit/TransformerTest.php
@@ -100,6 +100,25 @@ class TransformerTest extends \Codeception\Test\Unit
     /**
      * @covers \TypistTech\Imposter\Transformer
      */
+    public function testTransformExcludesGlobalNamespaceWithLeadingSlash()
+    {
+        $transformer = new Transformer('MyPlugin\Vendor', new Filesystem);
+
+        $transformer->transform($this->dummyFile);
+
+        $this->tester->openFile($this->dummyFile);
+        $this->tester->dontSeeInThisFile('use MyPlugin\Vendor\UnexpectedValueException;');
+        $this->tester->dontSeeInThisFile('use MyPlugin\Vendor\\\\UnexpectedValueException;');
+        $this->tester->dontSeeInThisFile('use \MyPlugin\Vendor\\\\UnexpectedValueException;');
+        $this->tester->dontSeeInThisFile('use \MyPlugin\Vendor\UnexpectedValueException;');
+        $this->tester->seeInThisFile('use \UnexpectedValueException;');
+
+        $this->assertTransformed($this->dummyFile);
+    }
+
+    /**
+     * @covers \TypistTech\Imposter\Transformer
+     */
     public function testTransformSingleLevelNamespace()
     {
         $path        = codecept_data_dir('tmp-vendor/dummy/dummy-excluded/DummyClass.php');


### PR DESCRIPTION
Skip transforming `use` keywords with leading slashes and global classes, i.e: 
```php
use \UnexpectedValueException;
```

Fix #58 