### PR TITLE
Fix https://github.com/TypistTech/imposter-plugin/issues/43 array_merge 0 args given

### DIFF
--- a/src/ArrayUtil.php
+++ b/src/ArrayUtil.php
@@ -21,6 +21,12 @@ class ArrayUtil
      */
     public static function flatten(array $array): array
     {
+        if ($array === null) {
+            return $array;
+        }
+        if (count($array) == 0) {
+            return $array;
+        }
         return call_user_func_array('array_merge', $array);
     }
 }


### PR DESCRIPTION
See TypistTech/imposter-plugin#43

- Fix ArrayUtil::flatten for null or empty arrays