### PR TITLE
Fix `array_merge` exception when `autoload`is not defined in package `composer.json`

### DIFF
--- a/src/ArrayUtil.php
+++ b/src/ArrayUtil.php
@@ -14,7 +14,7 @@ class ArrayUtil
     }
 
     /**
-     * Flatten array by one level.
+     * Flatten a multi-dimensional array into a single level.
      *
      * @param array $array
      *
@@ -22,6 +22,18 @@ class ArrayUtil
      */
     public static function flatten(array $array): array
     {
-        return call_user_func_array('array_merge', $array);
+        if (! is_array($array)) {
+            $array = (array) $array;
+        }
+
+        $result = [];
+        foreach ($array as $item) {
+            if (is_array($item)) {
+                $result = array_merge($result, array_values($item));
+            } else {
+                $result[] = $item;
+            }
+        }
+        return $result;
     }
 }

--- a/src/ArrayUtil.php
+++ b/src/ArrayUtil.php
@@ -14,7 +14,7 @@ class ArrayUtil
     }
 
     /**
-     * Flatten a multi-dimensional array into a single level.
+     * Flatten array by one level.
      *
      * @param array $array
      *

--- a/src/Config.php
+++ b/src/Config.php
@@ -27,7 +27,7 @@ class Config implements ConfigInterface
      */
     public function getAutoloads(): array
     {
-        return array_map(function (string $autoload) {
+        return array_map(function (string $autoload): string {
             return $this->packageDir . $autoload;
         }, array_unique($this->getAutoloadPaths()));
     }
@@ -37,11 +37,9 @@ class Config implements ConfigInterface
      */
     private function getAutoloadPaths(): array
     {
-        $autoload = $this->get('autoload');
-
-        return ArrayUtil::flattenMap(function ($autoloadConfig) {
+        return ArrayUtil::flattenMap(function ($autoloadConfig): array {
             return $this->normalizeAutoload($autoloadConfig);
-        }, $autoload);
+        }, $this->get('autoload'));
     }
 
     protected function get(string $key): array
@@ -60,7 +58,7 @@ class Config implements ConfigInterface
             return [$autoloadConfigs];
         }
 
-        return ArrayUtil::flattenMap(function ($autoloadConfig) {
+        return ArrayUtil::flattenMap(function ($autoloadConfig): array {
             return $this->normalizeAutoload($autoloadConfig);
         }, $autoloadConfigs);
     }

--- a/tests/_data/composer.json
+++ b/tests/_data/composer.json
@@ -3,6 +3,7 @@
     "php": "^7.0",
     "dummy/dummy": "*",
     "dummy/dummy-psr4": "*",
+    "dummy/dummy-no-autoload": "*",
     "typisttech/imposter": "*"
   },
   "require-dev": {

--- a/tests/_data/fake-vendor/dummy/dummy-no-autoload/composer.json
+++ b/tests/_data/fake-vendor/dummy/dummy-no-autoload/composer.json
@@ -1,0 +1,3 @@
+{
+  "name": "dummy/dummy-no-autoload"
+}

--- a/tests/unit/ArrayUtilTest.php
+++ b/tests/unit/ArrayUtilTest.php
@@ -40,6 +40,16 @@ class ArrayUtilTest extends Unit
     /**
      * @covers \TypistTech\Imposter\ArrayUtil
      */
+    public function testFlattenEmptyArray()
+    {
+        $actual = ArrayUtil::flatten([]);
+
+        $this->assertSame([], $actual);
+    }
+
+    /**
+     * @covers \TypistTech\Imposter\ArrayUtil
+     */
     public function testFlattenMap()
     {
         $array = [

--- a/tests/unit/ConfigCollectionFactoryTest.php
+++ b/tests/unit/ConfigCollectionFactoryTest.php
@@ -48,6 +48,12 @@ class ConfigCollectionFactoryTest extends Unit
         );
         $expected->add(
             ConfigFactory::build(
+                codecept_data_dir('tmp-vendor/dummy/dummy-no-autoload/composer.json'),
+                $filesystem
+            )
+        );
+        $expected->add(
+            ConfigFactory::build(
                 codecept_data_dir('tmp-vendor/dummy/dummy-dependency/composer.json'),
                 $filesystem
             )

--- a/tests/unit/ConfigTest.php
+++ b/tests/unit/ConfigTest.php
@@ -89,6 +89,19 @@ class ConfigTest extends Unit
     /**
      * @covers \TypistTech\Imposter\Config
      */
+    public function testGetAutoloadsWhenNotDefined()
+    {
+        $json = codecept_data_dir('tmp-vendor/dummy/dummy-no-autoload/composer.json');
+        $config = ConfigFactory::build($json, new Filesystem());
+
+        $actual = $config->getAutoloads();
+
+        $this->assertSame([], $actual);
+    }
+
+    /**
+     * @covers \TypistTech\Imposter\Config
+     */
     public function testGetPackageDir()
     {
         $expected = codecept_data_dir();
@@ -107,6 +120,7 @@ class ConfigTest extends Unit
             'php',
             'dummy/dummy',
             'dummy/dummy-psr4',
+            'dummy/dummy-no-autoload',
             'typisttech/imposter',
         ];
 


### PR DESCRIPTION
close https://github.com/typistTech/imposter-plugin/issues/43
close https://github.com/typistTech/imposter-plugin/issues/34
close #57
close #77

props to @cambell-prince