### PR TITLE
Ignore "exclude-from-classmap" entries

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -37,10 +37,10 @@ class Config implements ConfigInterface
      */
     private function getAutoloadPaths(): array
     {
-	    $autoloads = $this->get('autoload');
-		unset($autoloads['exclude-from-classmap']);
+        $autoloads = $this->get('autoload');
+        unset($autoloads['exclude-from-classmap']);
 
-	    return ArrayUtil::flattenMap(function ($autoloadConfig): array {
+        return ArrayUtil::flattenMap(function ($autoloadConfig): array {
             return $this->normalizeAutoload($autoloadConfig);
         }, $autoloads);
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -37,9 +37,12 @@ class Config implements ConfigInterface
      */
     private function getAutoloadPaths(): array
     {
-        return ArrayUtil::flattenMap(function ($autoloadConfig): array {
+	    $autoloads = $this->get('autoload');
+		unset($autoloads['exclude-from-classmap']);
+
+	    return ArrayUtil::flattenMap(function ($autoloadConfig): array {
             return $this->normalizeAutoload($autoloadConfig);
-        }, $this->get('autoload'));
+        }, $autoloads);
     }
 
     protected function get(string $key): array


### PR DESCRIPTION
"exclude-from-classmap" autoload key is used to exclude _dev_ classes that live in a namespace contained in one the _prod_ namespaces.

Considering that _dev_ stuff of required packages is not useful or available to the root package, I think that we can safely ignore the "exclude-from-classmap" entries, neatly solving the problem with Symfony packages that do not contain the "Tests" directory.