### PR TITLE
Skip non-existing `autoload` paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "0.4.x-dev"
+      "dev-master": "0.6.x-dev"
     }
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,11 @@
       "TypistTech\\Imposter\\": "src"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "TypistTech\\Imposter\\": "tests/unit"
+    }
+  },
   "scripts": {
     "pretag": [
       "composer update --no-suggest",

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -58,13 +58,25 @@ class Filesystem implements FilesystemInterface
     /**
      * Determine if the given path is a file.
      *
-     * @param  string $file
+     * @param  string $path
      *
      * @return bool
      */
-    public function isFile(string $file): bool
+    public function isFile(string $path): bool
     {
-        return is_file($file);
+        return is_file($path);
+    }
+
+    /**
+     * Determine if the given path is a directory.
+     *
+     * @param  string $path
+     *
+     * @return bool
+     */
+    public function isDir(string $path): bool
+    {
+        return is_dir($path);
     }
 
     /**

--- a/src/FilesystemInterface.php
+++ b/src/FilesystemInterface.php
@@ -34,11 +34,20 @@ interface FilesystemInterface
     /**
      * Determine if the given path is a file.
      *
-     * @param  string $file
+     * @param  string $path
      *
      * @return bool
      */
-    public function isFile(string $file): bool;
+    public function isFile(string $path): bool;
+
+    /**
+     * Determine if the given path is a directory.
+     *
+     * @param  string $path
+     *
+     * @return bool
+     */
+    public function isDir(string $path);
 
     /**
      * Write the contents of a file.

--- a/src/Imposter.php
+++ b/src/Imposter.php
@@ -12,6 +12,11 @@ class Imposter implements ImposterInterface
     private $autoloads;
 
     /**
+     * @var string[]
+     */
+    private $invalidAutoloads;
+
+    /**
      * @var ConfigCollectionInterface
      */
     private $configCollection;
@@ -22,15 +27,25 @@ class Imposter implements ImposterInterface
     private $transformer;
 
     /**
+     * @var FilesystemInterface
+     */
+    private $filesystem;
+
+    /**
      * Imposter constructor.
      *
      * @param ConfigCollectionInterface $configCollection
      * @param TransformerInterface      $transformer
+     * @param FilesystemInterface       $filesystem
      */
-    public function __construct(ConfigCollectionInterface $configCollection, TransformerInterface $transformer)
-    {
+    public function __construct(
+        ConfigCollectionInterface $configCollection,
+        TransformerInterface $transformer,
+        FilesystemInterface $filesystem
+    ) {
         $this->configCollection = $configCollection;
         $this->transformer = $transformer;
+        $this->filesystem = $filesystem;
     }
 
     /**
@@ -61,17 +76,49 @@ class Imposter implements ImposterInterface
     }
 
     /**
-     * Get all autoload paths.
+     * Get all valid (exist) autoload paths.
      *
      * @return string[]
      */
     public function getAutoloads(): array
     {
-        if (empty($this->autoloads)) {
-            $this->autoloads = $this->configCollection->getAutoloads();
+        if ($this->autoloads === null) {
+            $this->setAutoloads();
         }
 
         return $this->autoloads;
+    }
+
+    /**
+     * Get all autoload paths which defined in composer.json but not exist.
+     *
+     * @return string[]
+     */
+    public function getInvalidAutoloads(): array
+    {
+        if ($this->invalidAutoloads === null) {
+            $this->setAutoloads();
+        }
+
+        return $this->invalidAutoloads;
+    }
+
+    protected function setAutoloads(): void
+    {
+        $this->autoloads = [];
+        $this->invalidAutoloads = [];
+
+        $autoloads = $this->configCollection->getAutoloads();
+
+        foreach ($autoloads as $autoload) {
+            $isValid = $this->filesystem->isFile($autoload) || $this->filesystem->isDir($autoload);
+
+            if ($isValid) {
+                $this->autoloads[] = $autoload;
+            } else {
+                $this->invalidAutoloads[] = $autoload;
+            }
+        }
     }
 
     /**

--- a/src/ImposterFactory.php
+++ b/src/ImposterFactory.php
@@ -25,6 +25,6 @@ class ImposterFactory
             $filesystem
         );
 
-        return new Imposter($configCollection, $transformer);
+        return new Imposter($configCollection, $transformer, $filesystem);
     }
 }

--- a/src/ImposterInterface.php
+++ b/src/ImposterInterface.php
@@ -7,11 +7,18 @@ namespace TypistTech\Imposter;
 interface ImposterInterface
 {
     /**
-     * Get all autoload paths.
+     * Get all valid (exist) autoload paths.
      *
      * @return string[]
      */
     public function getAutoloads(): array;
+
+    /**
+     * Get all invalid (not exist) autoload paths.
+     *
+     * @return string[]
+     */
+    public function getInvalidAutoloads(): array;
 
     /**
      * Transform all autoload files.

--- a/tests/unit/FilesystemTest.php
+++ b/tests/unit/FilesystemTest.php
@@ -85,6 +85,30 @@ class FilesystemTest extends Unit
         $this->assertFalse($actual);
     }
 
+    /**
+     * @covers \TypistTech\Imposter\Filesystem
+     */
+    public function testIsDir()
+    {
+        $path = codecept_data_dir();
+
+        $actual = $this->filesystem->isDir($path);
+
+        $this->assertTrue($actual);
+    }
+
+    /**
+     * @covers \TypistTech\Imposter\Filesystem
+     */
+    public function testIsDirNotExist()
+    {
+        $path = codecept_data_dir('NotExist/');
+
+        $actual = $this->filesystem->isDir($path);
+
+        $this->assertFalse($actual);
+    }
+
     public function testIsInstanceOfFilesystemInterface()
     {
         $this->assertInstanceOf(FilesystemInterface::class, $this->filesystem);

--- a/tests/unit/ImposterFactoryTest.php
+++ b/tests/unit/ImposterFactoryTest.php
@@ -21,7 +21,7 @@ class ImposterFactoryTest extends Unit
 
         $actual = ImposterFactory::forProject(codecept_data_dir());
 
-        $expected = new Imposter($configCollection, $transformer);
+        $expected = new Imposter($configCollection, $transformer, $filesystem);
 
         $this->assertEquals($expected, $actual);
     }

--- a/tests/unit/ImposterTest.php
+++ b/tests/unit/ImposterTest.php
@@ -32,7 +32,21 @@ class ImposterTest extends Unit
     public function testGetAutoloads()
     {
         $actual = $this->imposter->getAutoloads();
-        $expected = $this->configCollection->getAutoloads();
+        $expected = [
+            'path/to/dir',
+            'path/to/file.php',
+        ];
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testGetInvalidAutoloads()
+    {
+        $actual = $this->imposter->getInvalidAutoloads();
+        $expected = [
+            'path/to/invalid-file.php',
+            'path/to/invalid-dir',
+        ];
 
         $this->assertSame($expected, $actual);
     }
@@ -73,6 +87,8 @@ class ImposterTest extends Unit
                                ->andReturn([
                                    'path/to/dir',
                                    'path/to/file.php',
+                                   'path/to/invalid-file.php',
+                                   'path/to/invalid-dir',
                                ]);
 
         $this->transformer = Mockery::spy(Transformer::class);
@@ -80,6 +96,14 @@ class ImposterTest extends Unit
                           ->withNoArgs()
                           ->andReturnNull();
 
-        $this->imposter = new Imposter($this->configCollection, $this->transformer);
+        $this->filesystem = Mockery::spy(Filesystem::class);
+        $this->filesystem->allows('isDir')
+                          ->with('path/to/dir')
+                          ->andReturnTrue();
+        $this->filesystem->allows('isFile')
+                         ->with('path/to/file.php')
+                         ->andReturnTrue();
+
+        $this->imposter = new Imposter($this->configCollection, $this->transformer, $this->filesystem);
     }
 }


### PR DESCRIPTION
A different implementation of #152. The difference is to make https://github.com/TypistTech/imposter-plugin easier to print warnings about non-existing `autoload` paths.

props to @alessandromorelli

close #152 